### PR TITLE
[fix] support newer pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@ import os, shutil
 from distutils.command.clean import clean as Clean
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 import re, ast
 
 # get version from __version__ variable in frappe/__init__.py


### PR DESCRIPTION
This branch isn't officially maintained anymore, but these lines will save some people a headache.

Trying to install frappe < v10 with pip > v9.0.3 throws this:

```
ERROR: Command errored out with exit status 1:
     command: /home/frappe/frappe-bench/env/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/frappe/frappe-bench/apps/frappe/setup.py'"'"'; __file__='"'"'/home/frappe/frappe-bench/apps/frappe/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info
         cwd: /home/frappe/frappe-bench/apps/frappe/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/frappe/frappe-bench/apps/frappe/setup.py", line 6, in <module>
        from pip.req import parse_requirements
    ImportError: No module named req
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

https://discuss.erpnext.com/t/unable-to-install-erpnext-v8-due-to-pip-v19/47892/6